### PR TITLE
Fix compiler warning in IP module

### DIFF
--- a/lib/ip.ex
+++ b/lib/ip.ex
@@ -407,7 +407,7 @@ defmodule IP do
     |> Macro.escape()
   end
 
-  defp s(caller, msg), do: raise SyntaxError, caller ++ [description: msg]
+  defp s(caller, msg), do: raise(SyntaxError, caller ++ [description: msg])
 
   @ctx [context: Elixir, import: Kernel]
   defp token_to_matchv(<<x>> <> _ = int_str, meta) when x in ?0..?9 do


### PR DESCRIPTION
Not sure if you're accepting pull requests for this project, but if so 
here's a small fix concerning a compiler warning that I've started to
notice on more recent Elixir versions.

On compiling with Elixir 1.15, a warning is omitted by the compiler:

  warning: missing parentheses for expression following "do:" keyword.
  Parentheses are required to solve ambiguity inside keywords.

This fix resolved that issue by simply adding the requested parentheses.